### PR TITLE
Fix error with directory separators, appears when using one settings.cfg

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -52,7 +52,7 @@ void settings::okSlot()
    dataManager* data=new dataManager();
    if(DataPathLine->text()!=data->getPath())
      {
-       data->setPath(DataPathLine->text());
+       data->setPath((QDir::fromNativeSeparators(DataPathLine->text())));
      }
 
    data->setCurrency(CurrencyLine->text());


### PR DESCRIPTION
fille on different os
